### PR TITLE
version 0.2.0

### DIFF
--- a/OPEN BLOCKCHAIN-SPECIFIC LICENSE
+++ b/OPEN BLOCKCHAIN-SPECIFIC LICENSE
@@ -4,17 +4,23 @@ Copyright <YEAR> <COPYRIGHT HOLDER>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction other than the conditions set out below, including without limitation the rights to use, copy, modify, merge, publish, distribute, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-1.  Blockchain Limitation. The grant to deal provided above is restricted to dealing in the Software only for purposes relating to the following:
+1.  Usage Limitations. The grant to deal provided above is restricted to dealing in the Software only for purposes relating to one or multiple of the following:
     - Purposes related to The Bitcoin SV Blockchain
-        - defined as the Bitcoin chain with the most SHA-265 Proof of Work accomulated, following block height #560000 with this hash: 0000000000000000035cb1baaf4f82d8358a8b9ed22aec52c2801a02b9c6f18f.
+        - defined as the Bitcoin chain with the most SHA-256 Proof of Work accumulated, following block height #560000 with this hash: 0000000000000000035cb1baaf4f82d8358a8b9ed22aec52c2801a02b9c6f18f.
     - Purposes related to The Bitcoin Blockchain
-        - defined as the Bitcoin chain with the most SHA-265 Proof of Work accomulated, following block height #1 with this hash: 00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048.
-    - Purposes not related to cryptohraphic currencies
-        - defined as any usage of the software that does not interact in any way with any form of money, or usages of the software that interact with government issued (FIAT) money.
+        - defined as the Bitcoin chain with the most SHA-256 Proof of Work accumulated, following block height #1 with this hash: 00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048.
+    - Purposes related to Government (FIAT) money.
+        - Defined as any form of money issued by a government and declared a legal tender by a government.
+    - Purposes not related to money
+        - defined as any usage of the software that does not interact in any way with any form of money
 
-    In case of competing blockchain forks, the license is valid on both chains, until one of them gains sufficient advantage over the other in terms of total acumolated hashpower.
-    A sufficient advantage is an advantage of at least 1000 blocks with the dificulty of the latest block on the chain with more acumolated hashpower.
-    
+    In case of competing blockchain protocols, if the difference of their total accumulated Proof of Work is less than the required sufficient advantage, the license is valid on both chains, until one of them gains sufficient advantage in accumulated proof of work.
+		- Competing protocols are defined as cryptocurrency protocols originating from the same genesis block (or block with a specific height and hash, if such is specified in the above permission notice) and using the same proof of work algorithm. 
+		- A sufficient advantage is an advantage of at least 1000 blocks with the difficulty of the latest block on the chain with more accumulated Proof of Work.
+		- The proof of work difficulty of a block is measured by the leading zeroes of its hash, where each extra zero is worth twice as much as the previous one.
+			- For example: A block with 4 leading zeroes is measured as 15 units of difficulty (1+2+4+8).
+		- The accumulated Proof of Work of a chain is defined as the sum of the difficulties of all the blocks in that chain.
+
 
 2.  Redistributions of all copies or substantial portions of the source code of the Software must retain the above copyright notice and above permission notice (with blockchain limitation), this list of conditions and the following disclaimer.
 
@@ -24,7 +30,3 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 
 5.  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
 HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OF OR OTHER DEALINGS IN THE SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-LICENSE APPLICABILITY
-
-This license applies to any person or entity that downloads, reproduces or obtains the Software on or after the Effective Date stated above.


### PR DESCRIPTION
- fixed typo in the word "accumulated"
- fixed typo in SHA algorithm name (265 to 256)
- more detailed and explicit permission for usage with FIAT money
- simpler definition of non-monetary usage permission
- changed "competing forks" to "competing protocols"
- defined "competing protocols"
- fixed typo in the word "difficulty"
- defined an algorithm to measure the difficulty of a PoW block
- defined "accumulated Proof of Work" of a chain
- removed the License Applicability clause (which was relating to a non-specified effective date)